### PR TITLE
Fix some warnings

### DIFF
--- a/wysihtml5/utils.py
+++ b/wysihtml5/utils.py
@@ -5,7 +5,7 @@ import re
 
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.functional import allow_lazy
-from django.utils.importlib import import_module
+from importlib import import_module
 
 
 def get_function(function_path):

--- a/wysihtml5/widgets.py
+++ b/wysihtml5/widgets.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 import six
 
 from django.contrib.admin.widgets import AdminTextareaWidget
-from django.forms.util import flatatt
+from django.forms.utils import flatatt
 try:
     from django.utils.encoding import force_text
 except ImportError:


### PR DESCRIPTION
- https://github.com/guybowden/django-wysihtml5/commit/7df584712918ce8b4a7b983caa907314736f6a96 fixes `RemovedInDjango19Warning: The django.forms.util module has been renamed. Use django.forms.utils instead.`
- https://github.com/guybowden/django-wysihtml5/commit/244b62025923793ad46f0ce964dd6a8b300c1b10 fixes `RemovedInDjango19Warning: django.utils.importlib will be removed in Django 1.9. from django.utils.importlib import import_module`